### PR TITLE
Allow default_generator proc to access the instance

### DIFF
--- a/lib/value_semantics/instance_methods.rb
+++ b/lib/value_semantics/instance_methods.rb
@@ -36,7 +36,7 @@ module ValueSemantics
         if remaining_attrs.delete(attr.name)
           value = attributes_hash.fetch(attr.name)
         elsif attr.optional?
-          value = attr.default_generator.()
+          value = instance_exec(&attr.default_generator)
         else
           missing_attrs ||= []
           missing_attrs << attr.name


### PR DESCRIPTION
This allows attribute defaults to make use of earlier attributes, etc